### PR TITLE
Implemented cursor capture

### DIFF
--- a/desktop/incl/ScreenCapture.h
+++ b/desktop/incl/ScreenCapture.h
@@ -4,6 +4,8 @@
 #include <dxgi1_2.h>
 #include <QImage>
 #include <QMutex>
+#include <QCursor>
+#include "PTR_INFO.h"
 
 class ScreenCapture
 {
@@ -19,6 +21,8 @@ private:
     bool initDirectX();
     bool initDuplication();
     void cleanup();
+    HRESULT getMouse(PTR_INFO* ptrInfo, DXGI_OUTDUPL_FRAME_INFO* frameInfo, int offsetX, int offsetY);
+    void drawMouse(QImage& image, PTR_INFO* ptrInfo);
 
     // DirectX objects
     ID3D11Device* m_d3dDevice = nullptr;
@@ -34,4 +38,14 @@ private:
     // Screen dimensions
     int m_screenWidth = 0;
     int m_screenHeight = 0;
+
+    // Output description 
+    DXGI_OUTPUT_DESC m_outputDesc;
+
+    // Pointer info
+    PTR_INFO m_ptrInfo;
+
+    // Output number
+    UINT m_outputNumber = 0;
+
 };


### PR DESCRIPTION
# 🎯 Implement Cursor Capture in DXGI Desktop Duplication  

## Summary  
This PR introduces cursor capture functionality in the `ScreenCapture` class using the DXGI Desktop Duplication API. The `getMouse()` and `drawMouse()` functions now enable proper retrieval and rendering of the cursor within the captured frames.  

## Implementation Details  
### `getMouse()` – Cursor Data Retrieval
- Acquires cursor metadata from `DXGI_OUTDUPL_FRAME_INFO`.  
- Extracts cursor shape from `DXGI_OUTDUPL_CURSOR_SHAPE_INFO`, supporting:  
  1. **Monochrome cursors** (bitmask-based).  
  2. **Color cursors** (direct pixel data).  
  3. **Masked color cursors** (composite format).  
- Converts cursor shape into a `QImage` for rendering.  

### `drawMouse()` – Cursor Rendering
- Ensures the cursor is visible before rendering.  
- Positions the cursor correctly relative to the captured frame.  
- Overlays the cursor on the screen capture image.  
- Handles transparency and masking to properly display custom cursors.  

## Improvements & Future Work  
- **Performance Optimization**: Potential for cursor caching to minimize repeated image allocations.  
- **Multi-Monitor Support**: Currently, cursor tracking is limited to a single display. Extending this to multiple monitors could improve usability.  

## Testing  
- Verified cursor rendering for different cursor types.  
- Tested cursor visibility and position consistency across captures.  
- Ensured proper integration with the existing screen capture workflow.  

## Related Issues  
- Closes #3